### PR TITLE
Removal of master-slave language

### DIFF
--- a/collector/plugins/mongodb/mongodb.go
+++ b/collector/plugins/mongodb/mongodb.go
@@ -449,7 +449,7 @@ func (m *MongoDB) collectReplSetGetStatus(session Session, tags *[]string, agg m
 		replSet := bson.M{}
 		var primary, current ReplSetMember
 
-		// find nodes: master and current node (ourself)
+		// find nodes: main and current node (ourself)
 		for _, member := range replStatus.Members {
 			if member.Self {
 				current = member

--- a/collector/plugins/mysql/mysql.go
+++ b/collector/plugins/mysql/mysql.go
@@ -306,8 +306,8 @@ var (
 	}
 
 	replicaVars = map[string]metric.Field{
-		"Seconds_Behind_Master": {"mysql.replication.seconds_behind_master", gauge},
-		"Slaves_connected":      {"mysql.replication.slaves_connected", count},
+		"Seconds_Behind_Main": {"mysql.replication.seconds_behind_main", gauge},
+		"Subordinates_connected":      {"mysql.replication.subordinates_connected", count},
 	}
 
 	syntheticVars = map[string]metric.Field{

--- a/collector/plugins/mysql/mysql_test.go
+++ b/collector/plugins/mysql/mysql_test.go
@@ -144,8 +144,8 @@ Per second averages calculated from the last 11 seconds
 -----------------
 BACKGROUND THREAD
 -----------------
-srv_master_thread loops: 1 1_second, 1 sleeps, 0 10_second, 1 background, 1 flush
-srv_master_thread log flush and writes: 1
+srv_main_thread loops: 1 1_second, 1 sleeps, 0 10_second, 1 background, 1 flush
+srv_main_thread log flush and writes: 1
 ----------
 SEMAPHORES
 ----------
@@ -240,8 +240,8 @@ Per second averages calculated from the last 25 seconds
 -----------------
 BACKGROUND THREAD
 -----------------
-srv_master_thread loops: 552 srv_active, 0 srv_shutdown, 376657 srv_idle
-srv_master_thread log flush and writes: 377209
+srv_main_thread loops: 552 srv_active, 0 srv_shutdown, 376657 srv_idle
+srv_main_thread log flush and writes: 377209
 ----------
 SEMAPHORES
 ----------
@@ -438,7 +438,7 @@ func TestCollectMetrics(t *testing.T) {
 		"mysql.performance.threads_cached":          float64(1),
 		"mysql.performance.threads_connected":       float64(1),
 		"mysql.performance.threads_running":         float64(1),
-		// "mysql.replication.slave_running":           float64(0),
+		// "mysql.replication.subordinate_running":           float64(0),
 	}
 	tags := []string{"env:production"}
 	for name, value := range fields {

--- a/collector/plugins/redis/redis_test.go
+++ b/collector/plugins/redis/redis_test.go
@@ -94,10 +94,10 @@ latest_fork_usec:903
 migrate_cached_sockets:0
 
 # Replication
-role:master
-connected_slaves:1
-slave0:ip=172.17.0.3,port=6379,state=online,offset=53445,lag=1
-master_repl_offset:53445
+role:main
+connected_subordinates:1
+subordinate0:ip=172.17.0.3,port=6379,state=online,offset=53445,lag=1
+main_repl_offset:53445
 repl_backlog_active:1
 repl_backlog_size:1048576
 repl_backlog_first_byte_offset:2
@@ -223,7 +223,7 @@ func TestCollectMetrics(t *testing.T) {
 
 		// Network
 		"redis.net.clients":  3,
-		"redis.net.slaves":   1,
+		"redis.net.subordinates":   1,
 		"redis.net.rejected": 0,
 
 		// clients
@@ -259,9 +259,9 @@ func TestCollectMetrics(t *testing.T) {
 		// "redis.replication.sync":               0,
 		// "redis.replication.sync_left_bytes":    0,
 		"redis.replication.backlog_histlen":    53444,
-		"redis.replication.master_repl_offset": 53445,
-		// "redis.replication.slave_repl_offset":  0,
-		// "redis.replication.master_link_down_since_seconds": 0,
+		"redis.replication.main_repl_offset": 53445,
+		// "redis.replication.subordinate_repl_offset":  0,
+		// "redis.replication.main_link_down_since_seconds": 0,
 	}
 	tags := []string{"service:redis"}
 	for name, value := range fields {
@@ -280,7 +280,7 @@ func TestCollectMetrics(t *testing.T) {
 	}
 
 	// replication
-	tags = []string{"service:redis", "slave_ip:172.17.0.3", "slave_port:6379", "slave_id:0"}
+	tags = []string{"service:redis", "subordinate_ip:172.17.0.3", "subordinate_port:6379", "subordinate_id:0"}
 	testutil.AssertContainsMetricWithTags(t, metrics, "redis.replication.delay", 0, tags)
 
 	// keys

--- a/vendor/github.com/docker/docker/api/types/mount/mount.go
+++ b/vendor/github.com/docker/docker/api/types/mount/mount.go
@@ -44,10 +44,10 @@ const (
 	PropagationRShared Propagation = "rshared"
 	// PropagationShared SHARED
 	PropagationShared Propagation = "shared"
-	// PropagationRSlave RSLAVE
-	PropagationRSlave Propagation = "rslave"
-	// PropagationSlave SLAVE
-	PropagationSlave Propagation = "slave"
+	// PropagationRSubordinate RSLAVE
+	PropagationRSubordinate Propagation = "rsubordinate"
+	// PropagationSubordinate SLAVE
+	PropagationSubordinate Propagation = "subordinate"
 )
 
 // Propagations is the list of all valid mount propagations
@@ -56,8 +56,8 @@ var Propagations = []Propagation{
 	PropagationPrivate,
 	PropagationRShared,
 	PropagationShared,
-	PropagationRSlave,
-	PropagationSlave,
+	PropagationRSubordinate,
+	PropagationSubordinate,
 }
 
 // BindOptions defines options specific to mounts of type "bind".

--- a/vendor/github.com/rafaeljusto/redigomock/redigomock.go
+++ b/vendor/github.com/rafaeljusto/redigomock/redigomock.go
@@ -143,7 +143,7 @@ func (c *Conn) Clear() {
 // response or error is returned. If no registered command is found an error
 // is returned
 func (c *Conn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
-	// @whazzmaster: Ensures that a call to Do() flushes the command queue
+	// @whazzmain: Ensures that a call to Do() flushes the command queue
 	//
 	// The redigo package ensures that a call to Do() will flush any commands
 	// that were queued via the Send() method, however a call to Do() on the

--- a/vendor/gopkg.in/mgo.v2/cluster.go
+++ b/vendor/gopkg.in/mgo.v2/cluster.go
@@ -51,7 +51,7 @@ type mongoCluster struct {
 	userSeeds    []string
 	dynaSeeds    []string
 	servers      mongoServers
-	masters      mongoServers
+	mains      mongoServers
 	references   int
 	syncing      bool
 	direct       bool
@@ -118,7 +118,7 @@ func (cluster *mongoCluster) LiveServers() (servers []string) {
 
 func (cluster *mongoCluster) removeServer(server *mongoServer) {
 	cluster.Lock()
-	cluster.masters.Remove(server)
+	cluster.mains.Remove(server)
 	other := cluster.servers.Remove(server)
 	cluster.Unlock()
 	if other != nil {
@@ -128,8 +128,8 @@ func (cluster *mongoCluster) removeServer(server *mongoServer) {
 	server.Close()
 }
 
-type isMasterResult struct {
-	IsMaster       bool
+type isMainResult struct {
+	IsMain       bool
 	Secondary      bool
 	Primary        string
 	Hosts          []string
@@ -140,11 +140,11 @@ type isMasterResult struct {
 	MaxWireVersion int    `bson:"maxWireVersion"`
 }
 
-func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResult) error {
-	// Monotonic let's it talk to a slave and still hold the socket.
+func (cluster *mongoCluster) isMain(socket *mongoSocket, result *isMainResult) error {
+	// Monotonic let's it talk to a subordinate and still hold the socket.
 	session := newSession(Monotonic, cluster, 10*time.Second)
 	session.setSocket(socket)
-	err := session.Run("ismaster", result)
+	err := session.Run("ismain", result)
 	session.Close()
 	return err
 }
@@ -170,7 +170,7 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 	log("SYNC Processing ", addr, "...")
 
 	// Retry a few times to avoid knocking a server down for a hiccup.
-	var result isMasterResult
+	var result isMainResult
 	var tryerr error
 	for retry := 0; ; retry++ {
 		if retry == 3 || retry == 1 && cluster.failFast {
@@ -193,14 +193,14 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 			logf("SYNC Failed to get socket to %s: %v", addr, err)
 			continue
 		}
-		err = cluster.isMaster(socket, &result)
+		err = cluster.isMain(socket, &result)
 		socket.Release()
 		if err != nil {
 			tryerr = err
-			logf("SYNC Command 'ismaster' to %s failed: %v", addr, err)
+			logf("SYNC Command 'ismain' to %s failed: %v", addr, err)
 			continue
 		}
-		debugf("SYNC Result of 'ismaster' from %s: %#v", addr, result)
+		debugf("SYNC Result of 'ismain' from %s: %#v", addr, result)
 		break
 	}
 
@@ -209,25 +209,25 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 		return nil, nil, fmt.Errorf("server %s is not a member of replica set %q", addr, cluster.setName)
 	}
 
-	if result.IsMaster {
-		debugf("SYNC %s is a master.", addr)
-		if !server.info.Master {
+	if result.IsMain {
+		debugf("SYNC %s is a main.", addr)
+		if !server.info.Main {
 			// Made an incorrect assumption above, so fix stats.
 			stats.conn(-1, false)
 			stats.conn(+1, true)
 		}
 	} else if result.Secondary {
-		debugf("SYNC %s is a slave.", addr)
+		debugf("SYNC %s is a subordinate.", addr)
 	} else if cluster.direct {
-		logf("SYNC %s in unknown state. Pretending it's a slave due to direct connection.", addr)
+		logf("SYNC %s in unknown state. Pretending it's a subordinate due to direct connection.", addr)
 	} else {
-		logf("SYNC %s is neither a master nor a slave.", addr)
+		logf("SYNC %s is neither a main nor a subordinate.", addr)
 		// Let stats track it as whatever was known before.
-		return nil, nil, errors.New(addr + " is not a master nor slave")
+		return nil, nil, errors.New(addr + " is not a main nor subordinate")
 	}
 
 	info = &mongoServerInfo{
-		Master:         result.IsMaster,
+		Main:         result.IsMain,
 		Mongos:         result.Msg == "isdbgrid",
 		Tags:           result.Tags,
 		SetName:        result.SetName,
@@ -236,7 +236,7 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 
 	hosts = make([]string, 0, 1+len(result.Hosts)+len(result.Passives))
 	if result.Primary != "" {
-		// First in the list to speed up master discovery.
+		// First in the list to speed up main discovery.
 		hosts = append(hosts, result.Primary)
 	}
 	hosts = append(hosts, result.Hosts...)
@@ -264,23 +264,23 @@ func (cluster *mongoCluster) addServer(server *mongoServer, info *mongoServerInf
 			return
 		}
 		cluster.servers.Add(server)
-		if info.Master {
-			cluster.masters.Add(server)
-			log("SYNC Adding ", server.Addr, " to cluster as a master.")
+		if info.Main {
+			cluster.mains.Add(server)
+			log("SYNC Adding ", server.Addr, " to cluster as a main.")
 		} else {
-			log("SYNC Adding ", server.Addr, " to cluster as a slave.")
+			log("SYNC Adding ", server.Addr, " to cluster as a subordinate.")
 		}
 	} else {
 		if server != current {
 			panic("addServer attempting to add duplicated server")
 		}
-		if server.Info().Master != info.Master {
-			if info.Master {
-				log("SYNC Server ", server.Addr, " is now a master.")
-				cluster.masters.Add(server)
+		if server.Info().Main != info.Main {
+			if info.Main {
+				log("SYNC Server ", server.Addr, " is now a main.")
+				cluster.mains.Add(server)
 			} else {
-				log("SYNC Server ", server.Addr, " is now a slave.")
-				cluster.masters.Remove(server)
+				log("SYNC Server ", server.Addr, " is now a subordinate.")
+				cluster.mains.Remove(server)
 			}
 		}
 	}
@@ -378,11 +378,11 @@ func (cluster *mongoCluster) syncServersLoop() {
 		// restart syncing if they wish to.
 		cluster.serverSynced.Broadcast()
 		// Check if we have to restart immediately either way.
-		restart := !direct && cluster.masters.Empty() || cluster.servers.Empty()
+		restart := !direct && cluster.mains.Empty() || cluster.servers.Empty()
 		cluster.Unlock()
 
 		if restart {
-			log("SYNC No masters found. Will synchronize again.")
+			log("SYNC No mains found. Will synchronize again.")
 			time.Sleep(syncShortDelay)
 			continue
 		}
@@ -484,8 +484,8 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 	seen := make(map[string]bool)
 	syncKind := partialSync
 
-	var spawnSync func(addr string, byMaster bool)
-	spawnSync = func(addr string, byMaster bool) {
+	var spawnSync func(addr string, byMain bool)
+	spawnSync = func(addr string, byMain bool) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -498,7 +498,7 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 			resolvedAddr := tcpaddr.String()
 
 			m.Lock()
-			if byMaster {
+			if byMain {
 				if pending, ok := notYetAdded[resolvedAddr]; ok {
 					delete(notYetAdded, resolvedAddr)
 					m.Unlock()
@@ -522,7 +522,7 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 			}
 
 			m.Lock()
-			add := direct || info.Master || addIfFound[resolvedAddr]
+			add := direct || info.Main || addIfFound[resolvedAddr]
 			if add {
 				syncKind = completeSync
 			} else {
@@ -534,7 +534,7 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 			}
 			if !direct {
 				for _, addr := range hosts {
-					spawnSync(addr, info.Master)
+					spawnSync(addr, info.Main)
 				}
 			}
 		}()
@@ -559,8 +559,8 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 	}
 
 	cluster.Lock()
-	mastersLen := cluster.masters.Len()
-	logf("SYNC Synchronization completed: %d master(s) and %d slave(s) alive.", mastersLen, cluster.servers.Len()-mastersLen)
+	mainsLen := cluster.mains.Len()
+	logf("SYNC Synchronization completed: %d main(s) and %d subordinate(s) alive.", mainsLen, cluster.servers.Len()-mainsLen)
 
 	// Update dynamic seeds, but only if we have any good servers. Otherwise,
 	// leave them alone for better chances of a successful sync in the future.
@@ -575,20 +575,20 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 	cluster.Unlock()
 }
 
-// AcquireSocket returns a socket to a server in the cluster.  If slaveOk is
-// true, it will attempt to return a socket to a slave server.  If it is
-// false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
+// AcquireSocket returns a socket to a server in the cluster.  If subordinateOk is
+// true, it will attempt to return a socket to a subordinate server.  If it is
+// false, the socket will necessarily be to a main server.
+func (cluster *mongoCluster) AcquireSocket(mode Mode, subordinateOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
 	var started time.Time
 	var syncCount uint
 	warnedLimit := false
 	for {
 		cluster.RLock()
 		for {
-			mastersLen := cluster.masters.Len()
-			slavesLen := cluster.servers.Len() - mastersLen
-			debugf("Cluster has %d known masters and %d known slaves.", mastersLen, slavesLen)
-			if !(slaveOk && mode == Secondary) && mastersLen > 0 || slaveOk && slavesLen > 0 {
+			mainsLen := cluster.mains.Len()
+			subordinatesLen := cluster.servers.Len() - mainsLen
+			debugf("Cluster has %d known mains and %d known subordinates.", mainsLen, subordinatesLen)
+			if !(subordinateOk && mode == Secondary) && mainsLen > 0 || subordinateOk && subordinatesLen > 0 {
 				break
 			}
 			if started.IsZero() {
@@ -607,10 +607,10 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 		}
 
 		var server *mongoServer
-		if slaveOk {
+		if subordinateOk {
 			server = cluster.servers.BestFit(mode, serverTags)
 		} else {
-			server = cluster.masters.BestFit(mode, nil)
+			server = cluster.mains.BestFit(mode, nil)
 		}
 		cluster.RUnlock()
 
@@ -634,11 +634,11 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 			cluster.syncServers()
 			continue
 		}
-		if abended && !slaveOk {
-			var result isMasterResult
-			err := cluster.isMaster(s, &result)
-			if err != nil || !result.IsMaster {
-				logf("Cannot confirm server %s as master (%v)", server.Addr, err)
+		if abended && !subordinateOk {
+			var result isMainResult
+			err := cluster.isMain(s, &result)
+			if err != nil || !result.IsMain {
+				logf("Cannot confirm server %s as main (%v)", server.Addr, err)
 				s.Release()
 				cluster.syncServers()
 				time.Sleep(100 * time.Millisecond)

--- a/vendor/gopkg.in/mgo.v2/server.go
+++ b/vendor/gopkg.in/mgo.v2/server.go
@@ -67,7 +67,7 @@ func (dial dialer) isSet() bool {
 }
 
 type mongoServerInfo struct {
-	Master         bool
+	Main         bool
 	Mongos         bool
 	Tags           bson.D
 	MaxWireVersion int
@@ -150,7 +150,7 @@ func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (
 // generally be done through server.AcquireSocket().
 func (server *mongoServer) Connect(timeout time.Duration) (*mongoSocket, error) {
 	server.RLock()
-	master := server.info.Master
+	main := server.info.Main
 	dial := server.dial
 	server.RUnlock()
 
@@ -180,7 +180,7 @@ func (server *mongoServer) Connect(timeout time.Duration) (*mongoSocket, error) 
 	}
 	logf("Connection to %s established.", server.Addr)
 
-	stats.conn(+1, master)
+	stats.conn(+1, main)
 	return newSocket(server, conn, timeout), nil
 }
 
@@ -293,7 +293,7 @@ func (server *mongoServer) pinger(loop bool) {
 	op := queryOp{
 		collection: "admin.$cmd",
 		query:      bson.D{{"ping", 1}},
-		flags:      flagSlaveOk,
+		flags:      flagSubordinateOk,
 		limit:      -1,
 	}
 	for {
@@ -421,9 +421,9 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		switch {
 		case serverTags != nil && !next.info.Mongos && !next.hasTags(serverTags):
 			// Must have requested tags.
-		case next.info.Master != best.info.Master && mode != Nearest:
-			// Prefer slaves, unless the mode is PrimaryPreferred.
-			swap = (mode == PrimaryPreferred) != best.info.Master
+		case next.info.Main != best.info.Main && mode != Nearest:
+			// Prefer subordinates, unless the mode is PrimaryPreferred.
+			swap = (mode == PrimaryPreferred) != best.info.Main
 		case absDuration(next.pingValue-best.pingValue) > 15*time.Millisecond:
 			// Prefer nearest server.
 			swap = next.pingValue < best.pingValue

--- a/vendor/gopkg.in/mgo.v2/session.go
+++ b/vendor/gopkg.in/mgo.v2/session.go
@@ -77,9 +77,9 @@ const (
 type Session struct {
 	m                sync.RWMutex
 	cluster_         *mongoCluster
-	slaveSocket      *mongoSocket
-	masterSocket     *mongoSocket
-	slaveOk          bool
+	subordinateSocket      *mongoSocket
+	mainSocket     *mongoSocket
+	subordinateOk          bool
 	consistency      Mode
 	queryConfig      query
 	safeOp           *queryOp
@@ -536,11 +536,11 @@ func newSession(consistency Mode, cluster *mongoCluster, timeout time.Duration) 
 func copySession(session *Session, keepCreds bool) (s *Session) {
 	cluster := session.cluster()
 	cluster.Acquire()
-	if session.masterSocket != nil {
-		session.masterSocket.Acquire()
+	if session.mainSocket != nil {
+		session.mainSocket.Acquire()
 	}
-	if session.slaveSocket != nil {
-		session.slaveSocket.Acquire()
+	if session.subordinateSocket != nil {
+		session.subordinateSocket.Acquire()
 	}
 	var creds []Credential
 	if keepCreds {
@@ -741,11 +741,11 @@ func (db *Database) Logout() {
 		}
 	}
 	if found {
-		if session.masterSocket != nil {
-			session.masterSocket.Logout(dbname)
+		if session.mainSocket != nil {
+			session.mainSocket.Logout(dbname)
 		}
-		if session.slaveSocket != nil {
-			session.slaveSocket.Logout(dbname)
+		if session.subordinateSocket != nil {
+			session.subordinateSocket.Logout(dbname)
 		}
 	}
 	session.m.Unlock()
@@ -755,11 +755,11 @@ func (db *Database) Logout() {
 func (s *Session) LogoutAll() {
 	s.m.Lock()
 	for _, cred := range s.creds {
-		if s.masterSocket != nil {
-			s.masterSocket.Logout(cred.Source)
+		if s.mainSocket != nil {
+			s.mainSocket.Logout(cred.Source)
 		}
-		if s.slaveSocket != nil {
-			s.slaveSocket.Logout(cred.Source)
+		if s.subordinateSocket != nil {
+			s.subordinateSocket.Logout(cred.Source)
 		}
 	}
 	s.creds = s.creds[0:0]
@@ -1575,7 +1575,7 @@ func (s *Session) cluster() *mongoCluster {
 // guarantees according to the current consistency setting for the session.
 func (s *Session) Refresh() {
 	s.m.Lock()
-	s.slaveOk = s.consistency != Strong
+	s.subordinateOk = s.consistency != Strong
 	s.unsetSocket()
 	s.m.Unlock()
 }
@@ -1622,15 +1622,15 @@ func (s *Session) Refresh() {
 // connection is unsuitable (to a secondary server in a Strong session).
 func (s *Session) SetMode(consistency Mode, refresh bool) {
 	s.m.Lock()
-	debugf("Session %p: setting mode %d with refresh=%v (master=%p, slave=%p)", s, consistency, refresh, s.masterSocket, s.slaveSocket)
+	debugf("Session %p: setting mode %d with refresh=%v (main=%p, subordinate=%p)", s, consistency, refresh, s.mainSocket, s.subordinateSocket)
 	s.consistency = consistency
 	if refresh {
-		s.slaveOk = s.consistency != Strong
+		s.subordinateOk = s.consistency != Strong
 		s.unsetSocket()
 	} else if s.consistency == Strong {
-		s.slaveOk = false
-	} else if s.masterSocket == nil {
-		s.slaveOk = true
+		s.subordinateOk = false
+	} else if s.mainSocket == nil {
+		s.subordinateOk = true
 	}
 	s.m.Unlock()
 }
@@ -1658,11 +1658,11 @@ func (s *Session) SetSyncTimeout(d time.Duration) {
 func (s *Session) SetSocketTimeout(d time.Duration) {
 	s.m.Lock()
 	s.sockTimeout = d
-	if s.masterSocket != nil {
-		s.masterSocket.SetTimeout(d)
+	if s.mainSocket != nil {
+		s.mainSocket.SetTimeout(d)
 	}
-	if s.slaveSocket != nil {
-		s.slaveSocket.SetTimeout(d)
+	if s.subordinateSocket != nil {
+		s.subordinateSocket.SetTimeout(d)
 	}
 	s.m.Unlock()
 }
@@ -2209,9 +2209,9 @@ func (c *Collection) NewIter(session *Session, firstBatch []bson.Raw, cursorId i
 	var server *mongoServer
 	csession := c.Database.Session
 	csession.m.RLock()
-	socket := csession.masterSocket
+	socket := csession.mainSocket
 	if socket == nil {
-		socket = csession.slaveSocket
+		socket = csession.subordinateSocket
 	}
 	if socket != nil {
 		server = socket.Server()
@@ -3487,8 +3487,8 @@ func (q *Query) Tail(timeout time.Duration) *Iter {
 func (s *Session) prepareQuery(op *queryOp) {
 	s.m.RLock()
 	op.mode = s.consistency
-	if s.slaveOk {
-		op.flags |= flagSlaveOk
+	if s.subordinateOk {
+		op.flags |= flagSubordinateOk
 	}
 	s.m.RUnlock()
 	return
@@ -4299,20 +4299,20 @@ func (s *Session) BuildInfo() (info BuildInfo, err error) {
 // ---------------------------------------------------------------------------
 // Internal session handling helpers.
 
-func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
+func (s *Session) acquireSocket(subordinateOk bool) (*mongoSocket, error) {
 
 	// Read-only lock to check for previously reserved socket.
 	s.m.RLock()
-	// If there is a slave socket reserved and its use is acceptable, take it as long
-	// as there isn't a master socket which would be preferred by the read preference mode.
-	if s.slaveSocket != nil && s.slaveOk && slaveOk && (s.masterSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
-		socket := s.slaveSocket
+	// If there is a subordinate socket reserved and its use is acceptable, take it as long
+	// as there isn't a main socket which would be preferred by the read preference mode.
+	if s.subordinateSocket != nil && s.subordinateOk && subordinateOk && (s.mainSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
+		socket := s.subordinateSocket
 		socket.Acquire()
 		s.m.RUnlock()
 		return socket, nil
 	}
-	if s.masterSocket != nil {
-		socket := s.masterSocket
+	if s.mainSocket != nil {
+		socket := s.mainSocket
 		socket.Acquire()
 		s.m.RUnlock()
 		return socket, nil
@@ -4324,17 +4324,17 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if s.slaveSocket != nil && s.slaveOk && slaveOk && (s.masterSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
-		s.slaveSocket.Acquire()
-		return s.slaveSocket, nil
+	if s.subordinateSocket != nil && s.subordinateOk && subordinateOk && (s.mainSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
+		s.subordinateSocket.Acquire()
+		return s.subordinateSocket, nil
 	}
-	if s.masterSocket != nil {
-		s.masterSocket.Acquire()
-		return s.masterSocket, nil
+	if s.mainSocket != nil {
+		s.mainSocket.Acquire()
+		return s.mainSocket, nil
 	}
 
 	// Still not good.  We need a new socket.
-	sock, err := s.cluster().AcquireSocket(s.consistency, slaveOk && s.slaveOk, s.syncTimeout, s.sockTimeout, s.queryConfig.op.serverTags, s.poolLimit)
+	sock, err := s.cluster().AcquireSocket(s.consistency, subordinateOk && s.subordinateOk, s.syncTimeout, s.sockTimeout, s.queryConfig.op.serverTags, s.poolLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -4347,16 +4347,16 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 
 	// Keep track of the new socket, if necessary.
 	// Note that, as a special case, if the Eventual session was
-	// not refreshed (s.slaveSocket != nil), it means the developer
+	// not refreshed (s.subordinateSocket != nil), it means the developer
 	// asked to preserve an existing reserved socket, so we'll
-	// keep a master one around too before a Refresh happens.
-	if s.consistency != Eventual || s.slaveSocket != nil {
+	// keep a main one around too before a Refresh happens.
+	if s.consistency != Eventual || s.subordinateSocket != nil {
 		s.setSocket(sock)
 	}
 
-	// Switch over a Monotonic session to the master.
-	if !slaveOk && s.consistency == Monotonic {
-		s.slaveOk = false
+	// Switch over a Monotonic session to the main.
+	if !subordinateOk && s.consistency == Monotonic {
+		s.subordinateOk = false
 	}
 
 	return sock, nil
@@ -4365,29 +4365,29 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 // setSocket binds socket to this section.
 func (s *Session) setSocket(socket *mongoSocket) {
 	info := socket.Acquire()
-	if info.Master {
-		if s.masterSocket != nil {
-			panic("setSocket(master) with existing master socket reserved")
+	if info.Main {
+		if s.mainSocket != nil {
+			panic("setSocket(main) with existing main socket reserved")
 		}
-		s.masterSocket = socket
+		s.mainSocket = socket
 	} else {
-		if s.slaveSocket != nil {
-			panic("setSocket(slave) with existing slave socket reserved")
+		if s.subordinateSocket != nil {
+			panic("setSocket(subordinate) with existing subordinate socket reserved")
 		}
-		s.slaveSocket = socket
+		s.subordinateSocket = socket
 	}
 }
 
-// unsetSocket releases any slave and/or master sockets reserved.
+// unsetSocket releases any subordinate and/or main sockets reserved.
 func (s *Session) unsetSocket() {
-	if s.masterSocket != nil {
-		s.masterSocket.Release()
+	if s.mainSocket != nil {
+		s.mainSocket.Release()
 	}
-	if s.slaveSocket != nil {
-		s.slaveSocket.Release()
+	if s.subordinateSocket != nil {
+		s.subordinateSocket.Release()
 	}
-	s.masterSocket = nil
-	s.slaveSocket = nil
+	s.mainSocket = nil
+	s.subordinateSocket = nil
 }
 
 func (iter *Iter) replyFunc() replyFunc {

--- a/vendor/gopkg.in/mgo.v2/stats.go
+++ b/vendor/gopkg.in/mgo.v2/stats.go
@@ -68,8 +68,8 @@ func ResetStats() {
 
 type Stats struct {
 	Clusters     int
-	MasterConns  int
-	SlaveConns   int
+	MainConns  int
+	SubordinateConns   int
 	SentOps      int
 	ReceivedOps  int
 	ReceivedDocs int
@@ -86,13 +86,13 @@ func (stats *Stats) cluster(delta int) {
 	}
 }
 
-func (stats *Stats) conn(delta int, master bool) {
+func (stats *Stats) conn(delta int, main bool) {
 	if stats != nil {
 		statsMutex.Lock()
-		if master {
-			stats.MasterConns += delta
+		if main {
+			stats.MainConns += delta
 		} else {
-			stats.SlaveConns += delta
+			stats.SubordinateConns += delta
 		}
 		statsMutex.Unlock()
 	}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.